### PR TITLE
AUSCO-26 Upcoming-Concerts-1

### DIFF
--- a/src/actions/getUpcomingConcerts.ts
+++ b/src/actions/getUpcomingConcerts.ts
@@ -1,0 +1,13 @@
+"use server";
+
+import { getPayload } from "@libs/payload";
+import { UpcomingConcert } from "@/payload-types";
+
+export const getUpcomingConcerts = async (): Promise<UpcomingConcert> => {
+  const payload = await getPayload();
+  const concerts = await payload.findGlobal({
+    slug: "upcoming-concerts",
+  });
+
+  return concerts;
+};

--- a/src/app/(frontend)/components/concerts/LandingPage.tsx
+++ b/src/app/(frontend)/components/concerts/LandingPage.tsx
@@ -1,8 +1,8 @@
 import { getConcertsLanding } from "@/actions/getConcertsLanding";
 import { Media } from "@/payload-types";
 import { ArrowUpRight } from "lucide-react";
-import { Archive } from 'lucide-react';
-import { CalendarClock } from 'lucide-react';
+import { Archive } from "lucide-react";
+import { CalendarClock } from "lucide-react";
 
 const LandingPage = async () => {
   const [content] = await Promise.all([getConcertsLanding()]);
@@ -14,13 +14,13 @@ const LandingPage = async () => {
     if (typeof imageField === "string") {
       return imageField;
     }
-      return undefined; // Return undefined if no image is found
-    };
+    return undefined; // Return undefined if no image is found
+  };
 
   return (
-    <div className="w-full bg-[#F6F4EC] pt-20 md:pt-25 md:h-[max(880px,100dvh)]">
+    <div className="w-full bg-[var(--cream)] pt-20 md:pt-25 md:h-[max(880px,100dvh)]">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-[#602C0F] text-center">Concerts</h1>
+        <h1 className="text-[var(--brown)] text-center">Concerts</h1>
 
         <div className="flex flex-col md:flex-row justify-center items-stretch gap-8 md:gap-12 pt-10">
           <div className="relative md:w-1/2 lg:w-1/2 aspect-4/3 rounded-lg overflow-hidden shadow-sm">
@@ -37,12 +37,12 @@ const LandingPage = async () => {
             )}
             <div className="absolute inset-0 bg-black opacity-70"></div>
 
-            <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-[#F6F4EC] px-2 py-4 lg:p-16">
-              <CalendarClock className="size-[40px] sm:size-[40px] text-[#F6F4EC]" />
+            <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-[var(--cream)] px-2 py-4 lg:p-16">
+              <CalendarClock className="size-[40px] sm:size-[40px] text-[var(--cream)]" />
               <h3 className="text-3xl lg:text-4xl font-bold my-4">Upcoming</h3>
               <span className="flex items-center justify-center">
                 <h3 className="text-3xl lg:text-4xl font-bold">Concerts</h3>
-                <ArrowUpRight className="size-[35px] text-[#F6F4EC] ml-2 translate-y-[5px]" />
+                <ArrowUpRight className="size-[35px] text-[var(--cream)] ml-2 translate-y-[5px]" />
               </span>
             </div>
           </div>
@@ -61,16 +61,15 @@ const LandingPage = async () => {
             )}
             <div className="absolute inset-0 bg-black opacity-70"></div>
 
-            <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-[#F6F4EC] px-2 py-4 lg:p-16">
-              <Archive className="size-[40px] sm:size-[40px] text-[#F6F4EC]" />
+            <div className="relative z-10 flex flex-col items-center justify-center h-full text-center text-[var(--cream)] px-2 py-4 lg:p-16">
+              <Archive className="size-[40px] sm:size-[40px] text-[var(--cream)]" />
               <h3 className="text-3xl lg:text-4xl font-bold my-4">Past</h3>
               <span className="flex items-center justify-center">
                 <h3 className="text-3xl lg:text-4xl font-bold">Concerts</h3>
-                <ArrowUpRight className="size-[35px] text-[#F6F4EC] ml-2 translate-y-[5px]" />
+                <ArrowUpRight className="size-[35px] text-[var(--cream)] ml-2 translate-y-[5px]" />
               </span>
             </div>
           </div>
-
         </div>
       </div>
     </div>

--- a/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
@@ -15,12 +15,12 @@ const EventInfo = ({ title, date, location, ticketUrl }: EventInfoProps) => (
       <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
       <span>{date}</span>
     </div>
-    <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
+    <div className="flex items-center gap-2 mb-2 md:mb-3 text-[var(--brown)]">
       <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
       <span>{location}</span>
     </div>
     {ticketUrl && (
-      <Button className="mt-2 -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border border-[var(--brown)] hover:bg-[var(--brown)] hover:text-[var(--beige)] px-8 py-4 rounded-lg">
+      <Button className="mt-2 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border-2 border-[var(--brown)] hover:bg-[var(--brown)] hover:text-[var(--beige)] px-8 py-4 rounded-lg">
         <a href={ticketUrl} className="flex items-center gap-2">
           <span>Tickets</span>
           <ArrowUpRight size={20} />

--- a/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
@@ -1,0 +1,33 @@
+import { Calendar, MapPin, ArrowUpRight } from "lucide-react";
+import { Button } from "@components/ui/button";
+
+interface EventInfoProps {
+  title?: string | null;
+  date?: string | null;
+  location?: string | null;
+  ticketUrl?: string | null;
+}
+
+const EventInfo = ({ title, date, location, ticketUrl }: EventInfoProps) => (
+  <div className="flex-1 flex flex-col">
+    <div className="font-bold mb-2">{title}</div>
+    <div className="flex items-center gap-2 mb-1">
+      <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+      <span>{date}</span>
+    </div>
+    <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
+      <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+      <span>{location}</span>
+    </div>
+    {ticketUrl && (
+      <Button className="mt-2 -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border border-[var(--brown)] hover:bg-[var(--brown)] hover:text-[var(--beige)] px-8 py-4 rounded-lg">
+        <a href={ticketUrl} className="flex items-center gap-2">
+          <span>Tickets</span>
+          <ArrowUpRight size={20} />
+        </a>
+      </Button>
+    )}
+  </div>
+);
+
+export default EventInfo;

--- a/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/EventInfo.tsx
@@ -1,3 +1,4 @@
+//component displays concert event details
 import { Calendar, MapPin, ArrowUpRight } from "lucide-react";
 import { Button } from "@components/ui/button";
 
@@ -8,8 +9,11 @@ interface EventInfoProps {
   ticketUrl?: string | null;
 }
 
+//event info and icon rendering
+//ticket button rendered if ticketUrl is provided
 const EventInfo = ({ title, date, location, ticketUrl }: EventInfoProps) => (
   <div className="flex-1 flex flex-col">
+    {/*event title, date, location + respective icons*/}
     <div className="font-bold mb-2">{title}</div>
     <div className="flex items-center gap-2 mb-1">
       <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
@@ -19,6 +23,7 @@ const EventInfo = ({ title, date, location, ticketUrl }: EventInfoProps) => (
       <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
       <span>{location}</span>
     </div>
+    {/*optional ticket button*/}
     {ticketUrl && (
       <Button className="mt-2 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border-2 border-[var(--brown)] hover:bg-[var(--brown)] hover:text-[var(--beige)] px-8 py-4 rounded-lg">
         <a href={ticketUrl} className="flex items-center gap-2">

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -1,4 +1,7 @@
+import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
+
 const HeroSection = async () => {
+  const concerts = await getUpcomingConcerts();
   return (
     <div className="w-full bg-[var(--cream)]  pt-40 pb-20">
       <div className="max-w-screen-xl mx-auto">

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -3,10 +3,10 @@ import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 const HeroSection = async () => {
   const concerts = await getUpcomingConcerts();
   return (
-    <div className="w-full bg-[var(--cream)] pt-50 pb-5">
-      <div className="max-w-3xl text-[var(--brown)] text-center mx-auto">
-        <h1>Upcoming Concerts</h1>
-        <p>{concerts.hero}</p>
+    <div className="m w-full bg-[var(--cream)] pt-10 sm:pt-16 md:pt-24 pb-4 ">
+      <div className="max-w-xl lg:max-w-3xl text-[var(--brown)] text-center mx-auto px-4">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-2">Upcoming Concerts</h1>
+        <p className="text-xs sm:text-sm md:text-base ">{concerts.hero}</p>
       </div>
     </div>
   );

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -3,9 +3,10 @@ import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 const HeroSection = async () => {
   const concerts = await getUpcomingConcerts();
   return (
-    <div className="w-full bg-[var(--cream)]  pt-40 pb-20">
-      <div className="max-w-screen-xl mx-auto">
+    <div className="w-full bg-[var(--cream)] pt-50 pb-5">
+      <div className="max-w-3xl  mx-auto">
         <h1 className="text-[var(--brown)] text-center">Upcoming Concerts</h1>
+        <p className="text-[var(--brown)] text-center">{concerts.hero}</p>
       </div>
     </div>
   );

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -4,9 +4,9 @@ const HeroSection = async () => {
   const concerts = await getUpcomingConcerts();
   return (
     <div className="w-full bg-[var(--cream)] pt-50 pb-5">
-      <div className="max-w-3xl  mx-auto">
-        <h1 className="text-[var(--brown)] text-center">Upcoming Concerts</h1>
-        <p className="text-[var(--brown)] text-center">{concerts.hero}</p>
+      <div className="max-w-3xl text-[var(--brown)] text-center mx-auto">
+        <h1>Upcoming Concerts</h1>
+        <p>{concerts.hero}</p>
       </div>
     </div>
   );

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -1,6 +1,8 @@
+//component for upcoming concerts page heading + short description
 import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 
 const HeroSection = async () => {
+  //fetch description from payload
   const concerts = await getUpcomingConcerts();
   return (
     <div className="m w-full bg-[var(--cream)] pt-10 sm:pt-16 md:pt-24 pb-4 ">

--- a/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/HeroSection.tsx
@@ -1,0 +1,11 @@
+const HeroSection = async () => {
+  return (
+    <div className="w-full bg-[var(--cream)]  pt-40 pb-20">
+      <div className="max-w-screen-xl mx-auto">
+        <h1 className="text-[var(--brown)] text-center">Upcoming Concerts</h1>
+      </div>
+    </div>
+  );
+};
+
+export default HeroSection;

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -38,7 +38,7 @@ const SemesterOneConcert = async () => {
           {/*card text + event info*/}
           <div className="flex-1 flex flex-col w-full md:max-w-lg gap-3 sm:gap-4">
             {/*row for semester tag + title*/}
-            <div className="flex flex-col lg:flex-row  gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:items-center">
+            <div className="flex flex-col lg:flex-row  gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:justify-center lg:items-center">
               <span className="bg-[var(--brown)] text-[var(--cream)] px-4 sm:px-6 py-2 sm:py-3 rounded-lg text-xs font-semibold w-fit mb-1 sm:mb-2 whitespace-nowrap">
                 Semester 1
               </span>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -16,34 +16,34 @@ const SemesterOneConcert = async () => {
   const descriptions = [description1, description2];
 
   return (
-    <div className="w-full bg-[var(--cream)] py-10">
-      <div className="max-w-screen-xl mx-auto p-16">
-        <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[700px] rounded-xl p-6 md:p-12 pt-40 pb-24 flex flex-col md:flex-row justify-evenly items-center gap-8">
+    <div className="w-full bg-[var(--cream)] py-6 sm:py-8 md:py-10">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 md:p-16">
+        <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[400px] md:min-h-[700px] rounded-xl p-4 sm:p-6 md:p-12 pt-4 sm:pt-24 pb-4 sm:pb-16  flex flex-col md:flex-row justify-evenly items-center gap-4 sm:gap-8">
           <Image
             src={posterUrl}
             alt={posterAlt}
             width={403}
             height={503}
-            className="rounded-lg border border-[var(--brown)] "
+            className="rounded-lg border border-[var(--brown)] w-full max-w-xs sm:max-w-sm md:w-[403px] md:h-[503px] object-cover"
           />
 
-          <div className="flex-1 flex flex-col max-w-lg gap-4">
-            <div className="flex gap-8 mb-6 flex-nowrap items-center">
-              <span className="bg-[var(--brown)] text-[var(--cream)] px-6 py-3 rounded-lg text-xs font-semibold w-fit mb-2 whitespace-nowrap">
+          <div className="flex-1 flex flex-col w-full md:max-w-lg gap-3 sm:gap-4">
+            <div className="flex flex-col sm:flex-row gap-2 sm:gap-8 mb-2 md:mb-6 flex-nowrap items-start sm:items-center">
+              <span className="bg-[var(--brown)] text-[var(--cream)] px-4 sm:px-6 py-2 sm:py-3 rounded-lg text-xs font-semibold w-fit mb-1 sm:mb-2 whitespace-nowrap">
                 Semester 1
               </span>
-              <h2 className="italic text-4xl font-bold">{title}</h2>
+              <h2 className="italic text-2xl sm:text-3xl md:text-4xl font-bold">{title}</h2>
             </div>
 
             {descriptions.map((dsc, i) => (
-              <p className="text-sm mb-2" key={i}>
+              <p className="md:text-sm text-xs mb-1 sm:mb-2" key={i}>
                 {dsc}
               </p>
             ))}
 
-            <hr className="border-t-[2px] border-[var(--brown)]" />
+            <hr className="border-t-[2px] border-[var(--brown)] md:mb-4 sm:mb-6" />
 
-            <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex flex-col sm:flex-row gap-6 md:gap-4">
               {[eventOne, eventTwo].map((event, j) => (
                 <EventInfo {...event} key={j} />
               ))}

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,24 +1,32 @@
+//component displays semester one concert info (title, poster, descriptions, performances)
 import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 import Image from "next/image";
 import EventInfo from "./EventInfo";
 
 const SemesterOneConcert = async () => {
+  //fetch upcoming concert data from payload
   const concerts = await getUpcomingConcerts();
   const concert = concerts.upcomingConcert;
   const eventOne = concerts.eventOne;
   const eventTwo = concerts.eventTwo;
 
+  //extract poster image from object
   const posterMedia =
     typeof concert?.poster === "object" && concert?.poster !== null ? concert.poster : undefined;
   const posterUrl = posterMedia?.url || "";
   const posterAlt = posterMedia?.alt || "Concert Poster";
+
+  //extract concert vars from object
   const { title, description1, description2 } = concert || {};
   const descriptions = [description1, description2];
 
   return (
+    //outer section background setup
     <div className="w-full bg-[var(--cream)] py-4 ">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 md:p-16">
+        {/*card container*/}
         <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[400px] md:min-h-[700px] rounded-xl p-4 sm:p-6 md:p-12 pt-4 sm:pt-24 pb-4 sm:pb-16  flex flex-col lg:flex-row justify-evenly items-center gap-4 sm:gap-8">
+          {/*image rendering setup*/}
           <Image
             src={posterUrl}
             alt={posterAlt}
@@ -27,7 +35,9 @@ const SemesterOneConcert = async () => {
             className="rounded-lg border border-[var(--brown)] w-full max-w-xs sm:max-w-sm md:max-w-md lg:w-[403px] lg:h-[503px] object-cover"
           />
 
+          {/*card text + event info*/}
           <div className="flex-1 flex flex-col w-full md:max-w-lg gap-3 sm:gap-4">
+            {/*row for semester tag + title*/}
             <div className="flex flex-col lg:flex-row  gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:items-center">
               <span className="bg-[var(--brown)] text-[var(--cream)] px-4 sm:px-6 py-2 sm:py-3 rounded-lg text-xs font-semibold w-fit mb-1 sm:mb-2 whitespace-nowrap">
                 Semester 1
@@ -35,14 +45,17 @@ const SemesterOneConcert = async () => {
               <h2 className="italic text-2xl sm:text-3xl md:text-4xl font-bold">{title}</h2>
             </div>
 
+            {/*mapping text descriptions*/}
             {descriptions.map((dsc, i) => (
               <p className="md:text-sm text-xs mb-1 sm:mb-2" key={i}>
                 {dsc}
               </p>
             ))}
 
+            {/*line divider*/}
             <hr className="border-t-[2px] border-[var(--brown)] md:mb-4 sm:mb-6" />
 
+            {/*mapping matinee + concert event info*/}
             <div className="flex flex-col sm:flex-row gap-6 md:gap-4">
               {[eventOne, eventTwo].map((event, j) => (
                 <EventInfo {...event} key={j} />

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -20,6 +20,15 @@ const SemesterOneConcert = async () => {
             height={503}
             className="rounded-lg border border-[var(--brown)] "
           />
+
+          <div className="flex-1 flex flex-col max-w-lg gap-4">
+            <div className="flex gap-8 mb-6">
+              <span className=" bg-[var(--brown)] text-[var(--cream)] px-6 py-3 rounded-lg text-xs font-semibold w-fit mb-2">
+                Semester 1
+              </span>
+              <h2 className="italic text-4xl font-bold">{concert?.title}</h2>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -7,10 +7,13 @@ const SemesterOneConcert = async () => {
   const concert = concerts.upcomingConcert;
   const eventOne = concerts.eventOne;
   const eventTwo = concerts.eventTwo;
+
   const posterMedia =
     typeof concert?.poster === "object" && concert?.poster !== null ? concert.poster : undefined;
   const posterUrl = posterMedia?.url || "";
   const posterAlt = posterMedia?.alt || "Concert Poster";
+  const { title, description1, description2 } = concert || {};
+  const descriptions = [description1, description2];
 
   return (
     <div className="w-full bg-[var(--cream)] py-10">
@@ -29,16 +32,21 @@ const SemesterOneConcert = async () => {
               <span className="bg-[var(--brown)] text-[var(--cream)] px-6 py-3 rounded-lg text-xs font-semibold w-fit mb-2 whitespace-nowrap">
                 Semester 1
               </span>
-              <h2 className="italic text-4xl font-bold">{concert?.title}</h2>
+              <h2 className="italic text-4xl font-bold">{title}</h2>
             </div>
 
-            <p className="text-sm mb-2">{concert?.description1}</p>
-            <p className="text-sm mb-2">{concert?.description2}</p>
+            {descriptions.map((dsc, i) => (
+              <p className="text-sm mb-2" key={i}>
+                {dsc}
+              </p>
+            ))}
+
             <hr className="border-t-[2px] border-[var(--brown)]" />
 
             <div className="flex flex-col sm:flex-row gap-4">
-              <EventInfo {...eventOne} />
-              <EventInfo {...eventTwo} />
+              {[eventOne, eventTwo].map((event, j) => (
+                <EventInfo {...event} key={j} />
+              ))}
             </div>
           </div>
         </div>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -2,7 +2,7 @@ import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 const SemesterOneConcert = async () => {
   const concerts = await getUpcomingConcerts();
   return (
-    <div className="w-full bg-[var(--cream)] pt-20 ">
+    <div className="w-full bg-[var(--cream)] p-5 ">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="bg-[var(--beige)] text-[var(--brown)] text-center p-4 rounded-lg">
           <h1>Semester One Concert</h1>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -22,8 +22,8 @@ const SemesterOneConcert = async () => {
           />
 
           <div className="flex-1 flex flex-col max-w-lg gap-4">
-            <div className="flex gap-8 mb-6">
-              <span className=" bg-[var(--brown)] text-[var(--cream)] px-6 py-3 rounded-lg text-xs font-semibold w-fit mb-2">
+            <div className="flex gap-8 mb-6 flex-nowrap items-center">
+              <span className="bg-[var(--brown)] text-[var(--cream)] px-6 py-3 rounded-lg text-xs font-semibold w-fit mb-2 whitespace-nowrap">
                 Semester 1
               </span>
               <h2 className="italic text-4xl font-bold">{concert?.title}</h2>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,12 +1,25 @@
 import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
+import Image from "next/image";
+
 const SemesterOneConcert = async () => {
   const concerts = await getUpcomingConcerts();
+  const concert = concerts.upcomingConcert;
+  const posterMedia =
+    typeof concert?.poster === "object" && concert?.poster !== null ? concert.poster : undefined;
+  const posterUrl = posterMedia?.url || "";
+  const posterAlt = posterMedia?.alt || "Concert Poster";
+
   return (
-    <div className="w-full bg-[var(--cream)] p-5 ">
-      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="bg-[var(--beige)] text-[var(--brown)] text-center p-4 rounded-lg">
-          <h1>Semester One Concert</h1>
-          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.</p>
+    <div className="w-full bg-[var(--cream)] py-10">
+      <div className="max-w-screen-xl mx-auto p-16">
+        <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[700px] rounded-xl p-6 md:p-12 pt-40 pb-24 flex flex-col md:flex-row justify-evenly items-center gap-8">
+          <Image
+            src={posterUrl}
+            alt={posterAlt}
+            width={403}
+            height={503}
+            className="rounded-lg border border-[var(--brown)] "
+          />
         </div>
       </div>
     </div>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -16,7 +16,7 @@ const SemesterOneConcert = async () => {
   const descriptions = [description1, description2];
 
   return (
-    <div className="w-full bg-[var(--cream)] py-6 sm:py-8 md:py-10">
+    <div className="w-full bg-[var(--cream)] py-4 ">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 md:p-16">
         <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[400px] md:min-h-[700px] rounded-xl p-4 sm:p-6 md:p-12 pt-4 sm:pt-24 pb-4 sm:pb-16  flex flex-col lg:flex-row justify-evenly items-center gap-4 sm:gap-8">
           <Image
@@ -28,7 +28,7 @@ const SemesterOneConcert = async () => {
           />
 
           <div className="flex-1 flex flex-col w-full md:max-w-lg gap-3 sm:gap-4">
-            <div className="flex flex-col lg:flex-row gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:items-center">
+            <div className="flex flex-col lg:flex-row  gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:items-center">
               <span className="bg-[var(--brown)] text-[var(--cream)] px-4 sm:px-6 py-2 sm:py-3 rounded-lg text-xs font-semibold w-fit mb-1 sm:mb-2 whitespace-nowrap">
                 Semester 1
               </span>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -28,6 +28,10 @@ const SemesterOneConcert = async () => {
               </span>
               <h2 className="italic text-4xl font-bold">{concert?.title}</h2>
             </div>
+
+            <p className="text-sm mb-2">{concert?.description1}</p>
+            <p className="text-sm mb-2">{concert?.description2}</p>
+            <hr className="border-t-[2px] border-[var(--brown)]" />
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,4 +1,6 @@
+import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 const SemesterOneConcert = async () => {
+  const concerts = await getUpcomingConcerts();
   return (
     <div className="w-full bg-[var(--cream)] pt-20 ">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,0 +1,14 @@
+const SemesterOneConcert = async () => {
+  return (
+    <div className="w-full bg-[var(--cream)] pt-20 ">
+      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="bg-[var(--beige)] text-[var(--brown)] text-center p-4 rounded-lg">
+          <h1>Semester One Concert</h1>
+          <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SemesterOneConcert;

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -18,17 +18,17 @@ const SemesterOneConcert = async () => {
   return (
     <div className="w-full bg-[var(--cream)] py-6 sm:py-8 md:py-10">
       <div className="max-w-screen-xl mx-auto px-4 sm:px-6 md:p-16">
-        <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[400px] md:min-h-[700px] rounded-xl p-4 sm:p-6 md:p-12 pt-4 sm:pt-24 pb-4 sm:pb-16  flex flex-col md:flex-row justify-evenly items-center gap-4 sm:gap-8">
+        <div className="bg-[var(--beige)] text-[var(--brown)] min-h-[400px] md:min-h-[700px] rounded-xl p-4 sm:p-6 md:p-12 pt-4 sm:pt-24 pb-4 sm:pb-16  flex flex-col lg:flex-row justify-evenly items-center gap-4 sm:gap-8">
           <Image
             src={posterUrl}
             alt={posterAlt}
             width={403}
             height={503}
-            className="rounded-lg border border-[var(--brown)] w-full max-w-xs sm:max-w-sm md:w-[403px] md:h-[503px] object-cover"
+            className="rounded-lg border border-[var(--brown)] w-full max-w-xs sm:max-w-sm md:max-w-md lg:w-[403px] lg:h-[503px] object-cover"
           />
 
           <div className="flex-1 flex flex-col w-full md:max-w-lg gap-3 sm:gap-4">
-            <div className="flex flex-col sm:flex-row gap-2 sm:gap-8 mb-2 md:mb-6 flex-nowrap items-start sm:items-center">
+            <div className="flex flex-col lg:flex-row gap-2 lg:gap-8 mb-2 md:mb-6 flex-nowrap items-start lg:items-center">
               <span className="bg-[var(--brown)] text-[var(--cream)] px-4 sm:px-6 py-2 sm:py-3 rounded-lg text-xs font-semibold w-fit mb-1 sm:mb-2 whitespace-nowrap">
                 Semester 1
               </span>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,9 +1,13 @@
 import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 import Image from "next/image";
+import { ArrowUpRight, Calendar, MapPin } from "lucide-react";
+import { Button } from "@components/ui/button";
 
 const SemesterOneConcert = async () => {
   const concerts = await getUpcomingConcerts();
   const concert = concerts.upcomingConcert;
+  const eventOne = concerts.eventOne;
+  const eventTwo = concerts.eventTwo;
   const posterMedia =
     typeof concert?.poster === "object" && concert?.poster !== null ? concert.poster : undefined;
   const posterUrl = posterMedia?.url || "";
@@ -32,6 +36,39 @@ const SemesterOneConcert = async () => {
             <p className="text-sm mb-2">{concert?.description1}</p>
             <p className="text-sm mb-2">{concert?.description2}</p>
             <hr className="border-t-[2px] border-[var(--brown)]" />
+
+            <div className="flex flex-col sm:flex-row gap-4"></div>
+            <div className="flex flex-col sm:flex-row ">
+              <div className="flex-1 flex flex-col ">
+                <div className="font-bold mb-2">{eventOne?.title}</div>
+                <div className="flex items-center gap-2 mb-1">
+                  <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+                  <p>{eventOne?.date}</p>
+                </div>
+                <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
+                  <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+                  <p>{eventOne?.location}</p>
+                </div>
+                <Button className="mt-2  -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border border-[#602C0F] hover:bg-[var(--brown)] hover:text-[var(--beige)] py-4 rounded-lg flex items-center gap-2">
+                  Tickets <ArrowUpRight size={20} />
+                </Button>
+              </div>
+
+              <div className="flex-1 flex flex-col  ">
+                <div className="font-bold mb-2">{eventTwo?.title}</div>
+                <div className="flex items-center gap-2 mb-1 text-[var(--brown)]">
+                  <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+                  <span>{eventTwo?.date}</span>
+                </div>
+                <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
+                  <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
+                  <span>{eventTwo?.location}</span>
+                </div>
+                <Button className="mt-2 -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border hover:bg-[var(--brown)] hover:text-[var(--beige)] border-[#602C0F] px-8 py-4 rounded-lg flex items-center gap-2">
+                  Tickets <ArrowUpRight size={20} />
+                </Button>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
+++ b/src/app/(frontend)/components/concerts/upcoming/SemesterOneConcert.tsx
@@ -1,7 +1,6 @@
 import { getUpcomingConcerts } from "@/actions/getUpcomingConcerts";
 import Image from "next/image";
-import { ArrowUpRight, Calendar, MapPin } from "lucide-react";
-import { Button } from "@components/ui/button";
+import EventInfo from "./EventInfo";
 
 const SemesterOneConcert = async () => {
   const concerts = await getUpcomingConcerts();
@@ -37,37 +36,9 @@ const SemesterOneConcert = async () => {
             <p className="text-sm mb-2">{concert?.description2}</p>
             <hr className="border-t-[2px] border-[var(--brown)]" />
 
-            <div className="flex flex-col sm:flex-row gap-4"></div>
-            <div className="flex flex-col sm:flex-row ">
-              <div className="flex-1 flex flex-col ">
-                <div className="font-bold mb-2">{eventOne?.title}</div>
-                <div className="flex items-center gap-2 mb-1">
-                  <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
-                  <p>{eventOne?.date}</p>
-                </div>
-                <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
-                  <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
-                  <p>{eventOne?.location}</p>
-                </div>
-                <Button className="mt-2  -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border border-[#602C0F] hover:bg-[var(--brown)] hover:text-[var(--beige)] py-4 rounded-lg flex items-center gap-2">
-                  Tickets <ArrowUpRight size={20} />
-                </Button>
-              </div>
-
-              <div className="flex-1 flex flex-col  ">
-                <div className="font-bold mb-2">{eventTwo?.title}</div>
-                <div className="flex items-center gap-2 mb-1 text-[var(--brown)]">
-                  <Calendar size={18} className="stroke-[var(--brown)] stroke-[3px]" />
-                  <span>{eventTwo?.date}</span>
-                </div>
-                <div className="flex items-center gap-2 mb-3 text-[var(--brown)]">
-                  <MapPin size={18} className="stroke-[var(--brown)] stroke-[3px]" />
-                  <span>{eventTwo?.location}</span>
-                </div>
-                <Button className="mt-2 -ml-2 lg:ml-0 h-10 lg:h-12 w-24 lg:w-28 bg-transparent text-[var(--brown)] border hover:bg-[var(--brown)] hover:text-[var(--beige)] border-[#602C0F] px-8 py-4 rounded-lg flex items-center gap-2">
-                  Tickets <ArrowUpRight size={20} />
-                </Button>
-              </div>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <EventInfo {...eventOne} />
+              <EventInfo {...eventTwo} />
             </div>
           </div>
         </div>

--- a/src/app/(frontend)/concerts/upcoming/page.tsx
+++ b/src/app/(frontend)/concerts/upcoming/page.tsx
@@ -1,3 +1,10 @@
+import HeroSection from "@components/concerts/upcoming/HeroSection";
+import SemesterOneConcert from "@components/concerts/upcoming/SemesterOneConcert";
 export default function Upcoming() {
-  return <h1>Upcoming Concerts</h1>;
+  return (
+    <>
+      <HeroSection />
+      <SemesterOneConcert />
+    </>
+  );
 }

--- a/src/collections/global/UpcomingConcerts.ts
+++ b/src/collections/global/UpcomingConcerts.ts
@@ -1,0 +1,94 @@
+import { GlobalConfig } from "payload";
+
+export const UpcomingConcerts: GlobalConfig = {
+  slug: "upcoming-concerts",
+  label: "Upcoming Concerts",
+  fields: [
+    { name: "hero", label: "Hero Text", type: "text", required: true },
+    {
+      name: "upcomingConcert",
+      label: "Upcoming Concert",
+      type: "group",
+      fields: [
+        {
+          name: "title",
+          label: "Title",
+          type: "text",
+        },
+        {
+          name: "poster",
+          label: "Poster",
+          type: "upload",
+          relationTo: "media",
+        },
+        {
+          name: "description",
+          label: "Description",
+          type: "text",
+        },
+      ],
+    },
+    {
+      name: "eventOne",
+      label: "Event One",
+      type: "group",
+      fields: [
+        {
+          name: "title",
+          label: "Event Title",
+          type: "text",
+          defaultValue: "Matinee",
+        },
+        {
+          name: "date",
+          label: "Event Date",
+          type: "text",
+          defaultValue: "Date TBC",
+        },
+        {
+          name: "location",
+          label: "Event Location",
+          type: "text",
+          defaultValue: "Location TBC",
+        },
+        {
+          name: "ticketUrl",
+          label: "Ticket Purchase URL",
+          type: "text",
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "eventTwo",
+      label: "Event Two",
+      type: "group",
+      fields: [
+        {
+          name: "title",
+          label: "Event Title",
+          type: "text",
+          defaultValue: "Concert",
+        },
+        {
+          name: "date",
+          label: "Event Date",
+          type: "text",
+          defaultValue: "Date TBC",
+        },
+        {
+          name: "location",
+          label: "Event Location",
+          type: "text",
+          defaultValue: "Location TBC",
+        },
+        {
+          name: "ticketUrl",
+          label: "Ticket Purchase URL",
+          type: "text",
+          required: false,
+        },
+      ],
+    },
+  ],
+};

--- a/src/collections/global/UpcomingConcerts.ts
+++ b/src/collections/global/UpcomingConcerts.ts
@@ -30,14 +30,14 @@ export const UpcomingConcerts: GlobalConfig = {
           relationTo: "media",
         },
         {
-          name: "descriptionOne",
+          name: "description1",
           label: "Description One",
           type: "text",
           defaultValue:
             "Love, Passion, and Loss. Our Semester 1 concert delves into the trials and tribulations of romance and its all-encompassing nature — as well as the grief we feel in its absence.",
         },
         {
-          name: "descriptionTwo",
+          name: "description2",
           label: "Description Two",
           type: "text",
           defaultValue:

--- a/src/collections/global/UpcomingConcerts.ts
+++ b/src/collections/global/UpcomingConcerts.ts
@@ -4,7 +4,14 @@ export const UpcomingConcerts: GlobalConfig = {
   slug: "upcoming-concerts",
   label: "Upcoming Concerts",
   fields: [
-    { name: "hero", label: "Hero Text", type: "text", required: true },
+    {
+      name: "hero",
+      label: "Hero Text",
+      type: "text",
+      required: true,
+      defaultValue:
+        "Short description - eg explaining that each year, AUSCO hosts 2 different concerts and performs them twice a year. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud.",
+    },
     {
       name: "upcomingConcert",
       label: "Upcoming Concert",
@@ -14,6 +21,7 @@ export const UpcomingConcerts: GlobalConfig = {
           name: "title",
           label: "Title",
           type: "text",
+          defaultValue: "Till Death do us \‘Part",
         },
         {
           name: "poster",
@@ -22,9 +30,18 @@ export const UpcomingConcerts: GlobalConfig = {
           relationTo: "media",
         },
         {
-          name: "description",
-          label: "Description",
+          name: "descriptionOne",
+          label: "Description One",
           type: "text",
+          defaultValue:
+            "Love, Passion, and Loss. Our Semester 1 concert delves into the trials and tribulations of romance and its all-encompassing nature — as well as the grief we feel in its absence.",
+        },
+        {
+          name: "descriptionTwo",
+          label: "Description Two",
+          type: "text",
+          defaultValue:
+            "That\'s why we\'ve partnered with Tōtara Hospice, in support of providing accessible, quality, and compassionate palliative care to those in their last moments.  All concert proceeds will go towards this cause.  Join us at one of our two concerts!",
         },
       ],
     },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -545,7 +545,8 @@ export interface UpcomingConcert {
   upcomingConcert?: {
     title?: string | null;
     poster?: (string | null) | Media;
-    description?: string | null;
+    descriptionOne?: string | null;
+    descriptionTwo?: string | null;
   };
   eventOne?: {
     title?: string | null;
@@ -788,7 +789,8 @@ export interface UpcomingConcertsSelect<T extends boolean = true> {
     | {
         title?: T;
         poster?: T;
-        description?: T;
+        descriptionOne?: T;
+        descriptionTwo?: T;
       };
   eventOne?:
     | T

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -545,8 +545,8 @@ export interface UpcomingConcert {
   upcomingConcert?: {
     title?: string | null;
     poster?: (string | null) | Media;
-    descriptionOne?: string | null;
-    descriptionTwo?: string | null;
+    description1?: string | null;
+    description2?: string | null;
   };
   eventOne?: {
     title?: string | null;
@@ -789,8 +789,8 @@ export interface UpcomingConcertsSelect<T extends boolean = true> {
     | {
         title?: T;
         poster?: T;
-        descriptionOne?: T;
-        descriptionTwo?: T;
+        description1?: T;
+        description2?: T;
       };
   eventOne?:
     | T

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -96,6 +96,7 @@ export interface Config {
     'second-two-card': SecondTwoCard;
     'our-people': OurPerson;
     'concerts-landing': ConcertsLanding;
+    'upcoming-concerts': UpcomingConcert;
   };
   globalsSelect: {
     'landing-page': LandingPageSelect<false> | LandingPageSelect<true>;
@@ -105,6 +106,7 @@ export interface Config {
     'second-two-card': SecondTwoCardSelect<false> | SecondTwoCardSelect<true>;
     'our-people': OurPeopleSelect<false> | OurPeopleSelect<true>;
     'concerts-landing': ConcertsLandingSelect<false> | ConcertsLandingSelect<true>;
+    'upcoming-concerts': UpcomingConcertsSelect<false> | UpcomingConcertsSelect<true>;
   };
   locale: null;
   user: User & {
@@ -535,6 +537,33 @@ export interface ConcertsLanding {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "upcoming-concerts".
+ */
+export interface UpcomingConcert {
+  id: string;
+  hero: string;
+  upcomingConcert?: {
+    title?: string | null;
+    poster?: (string | null) | Media;
+    description?: string | null;
+  };
+  eventOne?: {
+    title?: string | null;
+    date?: string | null;
+    location?: string | null;
+    ticketUrl?: string | null;
+  };
+  eventTwo?: {
+    title?: string | null;
+    date?: string | null;
+    location?: string | null;
+    ticketUrl?: string | null;
+  };
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "landing-page_select".
  */
 export interface LandingPageSelect<T extends boolean = true> {
@@ -743,6 +772,39 @@ export interface ConcertsLandingSelect<T extends boolean = true> {
     | T
     | {
         'background-image'?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "upcoming-concerts_select".
+ */
+export interface UpcomingConcertsSelect<T extends boolean = true> {
+  hero?: T;
+  upcomingConcert?:
+    | T
+    | {
+        title?: T;
+        poster?: T;
+        description?: T;
+      };
+  eventOne?:
+    | T
+    | {
+        title?: T;
+        date?: T;
+        location?: T;
+        ticketUrl?: T;
+      };
+  eventTwo?:
+    | T
+    | {
+        title?: T;
+        date?: T;
+        location?: T;
+        ticketUrl?: T;
       };
   updatedAt?: T;
   createdAt?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -20,6 +20,7 @@ import AboutFirstCards from "./collections/global/AboutFirstCards";
 import { ConcertsLanding } from "./collections/global/ConcertsLanding";
 
 import { OurPeople } from "./collections/global/OurPeople";
+import { UpcomingConcerts } from "./collections/global/UpcomingConcerts";
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -40,6 +41,7 @@ export default buildConfig({
     SecondTwoCard,
     OurPeople,
     ConcertsLanding,
+    UpcomingConcerts,
   ],
   collections: [Users, Media, Item, Videos],
   secret: process.env.PAYLOAD_SECRET || "",


### PR DESCRIPTION
## 🆔 Jira Ticket Number

AUSCO-26

## 📝 Description

Upcoming Concerts page:
- Implemented Hero and Semester One Concert components.
- Component content connected to payload global, allowing users to modify text + images (any content that is expected to need updating).
-  Additional EventInfo component - thought we could reuse this for sem two concert card (ticket button does not render if no url given) or the home page ticket section (let me know if you would like this coded in the card component instead, happy to change it back).
- Desktop, iPad, Mobile view supported.

## ✅ Checklist

- [x] All Next.js build checks are passing. (This can be technical - if you've tried to fix build errors but they persist, it's okay to leave this unchecked).
- [x] I have performed a self-review of my code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have moved my Jira ticket from IN PROGRESS to READY TO REVIEW.
- [x] I have verified that my pull request is merging my branch (right side) into the main branch (left side) - see the top banner, underneath the "Open a pull request" header.

## 📸 Notes

1. Desktop view (lg):
<img width="1288" height="924" alt="upcomingcard-lg" src="https://github.com/user-attachments/assets/3a9ffc0e-36cd-453f-8643-73ad5212e930" />

2. iPad view (md):
<img width="567" height="823" alt="upcomingcard-md" src="https://github.com/user-attachments/assets/299243e8-9c25-4a97-ba53-1d68f3a89ad8" />
<img width="561" height="817" alt="upcomingcard-md2" src="https://github.com/user-attachments/assets/9e5da1ed-2bd2-437d-9264-342d2d3d1fe4" />

3. Mobile view (sm):
<img width="378" height="831" alt="upcomingcard-sm" src="https://github.com/user-attachments/assets/bf9b752a-e063-4acc-baff-b5d21b7d02de" />
<img width="388" height="838" alt="upcomingcard-sm2" src="https://github.com/user-attachments/assets/840de791-617d-45f4-a803-3033aa7ddbca" />
Unsure of how this looks - may add padding to align appearance with other screen formats.

## 🚨 Risks

- Encountered visual bug where small black space separates hero and card components while testing on iPad Air (820 x 1180) and similar screens. When I zoom in to 200% and zoom back out, black space disappears.
- Difficult to make components iPad Pro friendly (registers as lg screen, same as desktop).
