### PR TITLE
AUSCO-56 Fix - Home Page Video Scale: unclampedScale rate fixed

### DIFF
--- a/src/app/(frontend)/components/home/PastConcert.tsx
+++ b/src/app/(frontend)/components/home/PastConcert.tsx
@@ -31,7 +31,8 @@ const PastConcert = () => {
   });
 
   //scaling animation
-  const unclampedScale = useTransform(scrollYProgress, [0.35, 0.6], [1, maxScale]);
+  //reaches maxScale early
+  const unclampedScale = useTransform(scrollYProgress, [0.25, 0.45], [1, maxScale]);
   const scaleValue = useTransform(unclampedScale, (v) => Math.max(1, Math.min(maxScale, v)));
 
   //bg colour transform


### PR DESCRIPTION
## 🆔 Jira Ticket Number

<!-- Please enter your Jira ticket number here (e.g., AUSCO-12) -->

AUSCO-56

## 📝 Description

<!-- Please include a brief summary of the changes you have made. -->

'unclampedScale' rate adjusted, maximum scale is now 0.45, so the header won't interrupt the video.
If there's a better way to solve this, feel free to leave any suggestions!

## ✅ Checklist

<!-- To complete an item, type "x" inside the brackets like this: [x] -->

- [x ] All Next.js build checks are passing.
- [x] I have performed a self-review of my code.
- [x ] I have commented my code in hard-to-understand areas.
- [x ] I have moved my Jira ticket from IN PROGRESS to READY TO REVIEW.
- [x ] I have verified that my pull request is merging my branch (right side) into the main branch (left side) - see the top banner, underneath the "Open a pull request" header.

## 📸 Notes

<!-- Add screenshots and/or extra information that might help the team understand your changes better. -->
<img width="1455" height="910" alt="image" src="https://github.com/user-attachments/assets/b4222de3-96d2-482a-8138-28225ea4b659" />

## 🚨 Risks

<!-- Are there any known bugs, unfinished work, or potential issues the team should be aware of? Mention any future tasks related to this PR here. -->

